### PR TITLE
Moving window to a workspace now respect the ignore rules

### DIFF
--- a/src/hyprfloat/hyprfloat.py
+++ b/src/hyprfloat/hyprfloat.py
@@ -192,9 +192,6 @@ class Hyprfloat:
 			target_workspace = next((w for w in workspaces if w['id'] == target_workspace_id), None)
 			target_monitor = target_workspace['monitor'] if target_workspace else None
 			
-			# Handle the target workspace
-			self.handle_change(target_workspace_windows, target_monitor, (event_type, event_data))
-			
 			# Also check the active workspace (source) - it might now have only 1 window left
 			active_workspace = json.loads(hyprctl(['activeworkspace', '-j']).stdout)
 			if active_workspace['id'] != target_workspace_id:


### PR DESCRIPTION
Fixes issue #16 where windows were being tiled when moved between workspaces even if they matched patterns in the ignore_titles configuration.